### PR TITLE
More flexible Job listing/killing for Slurm

### DIFF
--- a/R/clusterFunctionsSlurm.R
+++ b/R/clusterFunctionsSlurm.R
@@ -92,19 +92,24 @@ makeClusterFunctionsSlurm = function(template = "slurm", clusters = NULL, array.
   }
 
   listJobsQueued = function(reg) {
-    args = c("-h", "-o %i", "-u $USER", "-t PD", sprintf("--clusters=%s", clusters))
+    args = c("-h", "-o %i", "-u $USER", "-t PD",
+      sprintf("--clusters=%s", coalesce(clusters, reg$default.resources$clusters)),
+      sprintf("--partition=%s", coalesce(reg$default.resources$partition)))
     listJobs(reg, args)
   }
 
   listJobsRunning = function(reg) {
-    args = c("-h", "-o %i", "-u $USER", "-t R,S,CG", sprintf("--clusters=%s", clusters))
+    args = c("-h", "-o %i", "-u $USER", "-t R,S,CG",
+      sprintf("--clusters=%s", coalesce(clusters, reg$default.resources$clusters)),
+      sprintf("--partition=%s", coalesce(reg$default.resources$partition)))
     listJobs(reg, args)
   }
 
   killJob = function(reg, batch.id) {
     assertRegistry(reg, writeable = TRUE)
     assertString(batch.id)
-    cfKillJob(reg, "scancel", c(sprintf("--clusters=%s", clusters), batch.id), nodename = nodename)
+    cfKillJob(reg, "scancel", c(sprintf("--clusters=%s", coalesce(clusters, reg$default.resources$clusters)),
+      sprintf("--partition=%s", coalesce(reg$default.resources$partition)), batch.id), nodename = nodename)
   }
 
   makeClusterFunctions(name = "Slurm", submitJob = submitJob, killJob = killJob, listJobsRunning = listJobsRunning,

--- a/R/clusterFunctionsSlurm.R
+++ b/R/clusterFunctionsSlurm.R
@@ -92,24 +92,30 @@ makeClusterFunctionsSlurm = function(template = "slurm", clusters = NULL, array.
   }
 
   listJobsQueued = function(reg) {
+    if (is.null(clusters) && !is.null(reg$default.resources$clusters))
+      clusters = reg$default.resources$clusters
     args = c("-h", "-o %i", "-u $USER", "-t PD",
-      sprintf("--clusters=%s", coalesce(clusters, reg$default.resources$clusters)),
-      sprintf("--partition=%s", coalesce(reg$default.resources$partition)))
+      sprintf("--clusters=%s", clusters),
+      sprintf("--partition=%s", reg$default.resources$partition))
     listJobs(reg, args)
   }
 
   listJobsRunning = function(reg) {
+    if (is.null(clusters) && !is.null(reg$default.resources$clusters))
+      clusters = reg$default.resources$clusters
     args = c("-h", "-o %i", "-u $USER", "-t R,S,CG",
-      sprintf("--clusters=%s", coalesce(clusters, reg$default.resources$clusters)),
-      sprintf("--partition=%s", coalesce(reg$default.resources$partition)))
+      sprintf("--clusters=%s", clusters),
+      sprintf("--partition=%s", reg$default.resources$partition))
     listJobs(reg, args)
   }
 
   killJob = function(reg, batch.id) {
     assertRegistry(reg, writeable = TRUE)
     assertString(batch.id)
-    cfKillJob(reg, "scancel", c(sprintf("--clusters=%s", coalesce(clusters, reg$default.resources$clusters)),
-      sprintf("--partition=%s", coalesce(reg$default.resources$partition)), batch.id), nodename = nodename)
+    if (is.null(clusters) && !is.null(reg$default.resources$clusters))
+      clusters = reg$default.resources$clusters
+    cfKillJob(reg, "scancel", c(sprintf("--clusters=%s", clusters),
+      sprintf("--partition=%s", reg$default.resources$partition), batch.id), nodename = nodename)
   }
 
   makeClusterFunctions(name = "Slurm", submitJob = submitJob, killJob = killJob, listJobsRunning = listJobsRunning,


### PR DESCRIPTION
We frequently change clusters/partition on our HPC and setting the clusters in makeClusterFunctionSlurm() is not really practical (multiple users are linking to the same template/config file).

So we handle the clusters/partitions via resources. To make listing/killing of the jobs possible we need to set the squeue arguments in the functions accordingly.  

This is not really nice, but I can't think of another solution. As far as I know you can't change the clusters argument of makeClusterFunctionSlurm not after or while creating the registry.
